### PR TITLE
Define raw_input() and unicode() for Python 3

### DIFF
--- a/pwnedornot.py
+++ b/pwnedornot.py
@@ -12,6 +12,17 @@ G = '\033[32m' # green
 C = '\033[36m' # cyan
 W = '\033[0m'  # white
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
+try:
+    unicode            # Python 2
+except NameError:
+    unicode = str      # Python 3
+
+
 def banner():
 
 	os.system('clear')


### PR DESCRIPTION
https://pythonclock.org One Year, Seven Months...

flake8 testing of https://github.com/thewhiteh4t/pwnedOrNot on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pwnedornot.py:35:9: F821 undefined name 'raw_input'
	addr = raw_input(G + '[+]' + C + ' Enter Email Address : ' + W)
        ^
./pwnedornot.py:61:47: F821 undefined name 'unicode'
				+ G + '[+]' + C + ' Breach      : ' + W + unicode(item['Title']) + '\n' 
                                              ^
./pwnedornot.py:62:47: F821 undefined name 'unicode'
				+ G + '[+]' + C + ' Domain      : ' + W + unicode(item['Domain']) + '\n' 
                                              ^
./pwnedornot.py:63:47: F821 undefined name 'unicode'
				+ G + '[+]' + C + ' Date        : ' + W + unicode(item['BreachDate']) + '\n'
                                              ^
./pwnedornot.py:64:47: F821 undefined name 'unicode'
				+ G + '[+]' + C + ' Fabricated  : ' + W + unicode(item['IsFabricated']) + '\n'
                                              ^
./pwnedornot.py:65:47: F821 undefined name 'unicode'
				+ G + '[+]' + C + ' Verified    : ' + W + unicode(item['IsVerified']) + '\n'
                                              ^
./pwnedornot.py:66:47: F821 undefined name 'unicode'
				+ G + '[+]' + C + ' Retired     : ' + W + unicode(item['IsRetired']) + '\n'
                                              ^
./pwnedornot.py:67:47: F821 undefined name 'unicode'
				+ G + '[+]' + C + ' Spam        : ' + W + unicode(item['IsSpamList'])).encode('utf-8')
                                              ^
8     F821 undefined name 'raw_input'
8
```